### PR TITLE
fix: postgres syntax

### DIFF
--- a/blog-server-services/src/impls/rbatis_author_service.rs
+++ b/blog-server-services/src/impls/rbatis_author_service.rs
@@ -14,7 +14,7 @@ impl_select!(Author {select_all_with_offset_and_limit(offset: &i64, limit: &i64)
 impl Author {
     #[py_sql(
         "
-        SELECT COUNT(*) \
+        SELECT COUNT(1) \
         FROM author \
     "
     )]

--- a/blog-server-services/src/impls/rbatis_post_service.rs
+++ b/blog-server-services/src/impls/rbatis_post_service.rs
@@ -27,7 +27,7 @@ impl Post {
             author.last_name AS author_last_name, \
             string_agg(concat_ws(',', tag.slug, tag.title), ';') as tags \
         FROM post \
-        LEFT JOIN author ON post.author_id = author.id \
+        JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
         WHERE post.id = #{id} \
@@ -47,7 +47,7 @@ impl Post {
             author.last_name AS author_last_name, \
             string_agg(concat_ws(',', tag.slug, tag.title), ';') as tags \
         FROM post \
-        LEFT JOIN author ON post.author_id = author.id \
+        JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
         WHERE post.slug = #{slug} \

--- a/blog-server-services/src/impls/rbatis_post_service.rs
+++ b/blog-server-services/src/impls/rbatis_post_service.rs
@@ -65,7 +65,7 @@ impl Post {
             author.slug AS author_slug, \
             author.first_name AS author_first_name, \
             author.last_name AS author_last_name, \
-            string_agg(concat_ws(',', tag.title, tag.slug), ';') as tags \
+            string_agg(concat_ws(',', tag.slug, tag.title), ';') as tags \
         FROM post \
         JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \

--- a/blog-server-services/src/impls/rbatis_post_service.rs
+++ b/blog-server-services/src/impls/rbatis_post_service.rs
@@ -11,7 +11,7 @@ impl_insert!(BasePost {}, "post");
 impl Post {
     #[py_sql(
         "
-        SELECT COUNT(*) \
+        SELECT COUNT(1) \
         FROM post \
     "
     )]
@@ -25,13 +25,13 @@ impl Post {
             author.slug AS author_slug, \
             author.first_name AS author_first_name, \
             author.last_name AS author_last_name, \
-            string_agg(CONCAT_WS(',', tag.slug, tag.title), ';') as tags \
+            string_agg(concat_ws(',', tag.slug, tag.title), ';') as tags \
         FROM post \
         LEFT JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
         WHERE post.id = #{id} \
-        GROUP BY post.Id, author.slug, author.first_name, author.last_name \
+        GROUP BY post.id, author.slug, author.first_name, author.last_name \
         LIMIT 1 \
     "
     )]
@@ -45,13 +45,13 @@ impl Post {
             author.slug AS author_slug, \
             author.first_name AS author_first_name, \
             author.last_name AS author_last_name, \
-            string_agg(CONCAT_WS(',', tag.slug, tag.title), ';') as tags \
+            string_agg(concat_ws(',', tag.slug, tag.title), ';') as tags \
         FROM post \
         LEFT JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
         WHERE post.slug = #{slug} \
-        GROUP BY post.Id, author.slug, author.first_name, author.last_name \
+        GROUP BY post.id, author.slug, author.first_name, author.last_name \
         LIMIT 1 \
     "
     )]
@@ -70,7 +70,7 @@ impl Post {
         JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
-        GROUP BY post.Id, author.slug, author.first_name, author.last_name \
+        GROUP BY post.id, author.slug, author.first_name, author.last_name \
         LIMIT #{limit} \
         OFFSET #{offset} \
     "

--- a/blog-server-services/src/impls/rbatis_post_service.rs
+++ b/blog-server-services/src/impls/rbatis_post_service.rs
@@ -25,13 +25,13 @@ impl Post {
             author.slug AS author_slug, \
             author.first_name AS author_first_name, \
             author.last_name AS author_last_name, \
-            GROUP_CONCAT(CONCAT_WS(',', tag.slug, tag.title) SEPARATOR ';') as tags \
+            string_agg(CONCAT_WS(',', tag.slug, tag.title), ';') as tags \
         FROM post \
         LEFT JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
         WHERE post.id = #{id} \
-        GROUP BY post.id \
+        GROUP BY post.Id, author.slug, author.first_name, author.last_name \
         LIMIT 1 \
     "
     )]
@@ -45,13 +45,13 @@ impl Post {
             author.slug AS author_slug, \
             author.first_name AS author_first_name, \
             author.last_name AS author_last_name, \
-            GROUP_CONCAT(CONCAT_WS(',', tag.slug, tag.title) SEPARATOR ';') as tags \
+            string_agg(CONCAT_WS(',', tag.slug, tag.title), ';') as tags \
         FROM post \
         LEFT JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
         WHERE post.slug = #{slug} \
-        GROUP BY post.id \
+        GROUP BY post.Id, author.slug, author.first_name, author.last_name \
         LIMIT 1 \
     "
     )]
@@ -65,12 +65,12 @@ impl Post {
             author.slug AS author_slug, \
             author.first_name AS author_first_name, \
             author.last_name AS author_last_name, \
-            GROUP_CONCAT(CONCAT_WS(',', tag.slug, tag.title) SEPARATOR ';') as tags \
+            string_agg(concat_ws(',', tag.title, tag.slug), ';') as tags \
         FROM post \
-        LEFT JOIN author ON post.author_id = author.id \
+        JOIN author ON post.author_id = author.id \
         LEFT JOIN post_tag ON post_tag.post_id  = post.id \
         LEFT JOIN tag ON tag.id = post_tag.tag_id \
-        GROUP BY post.id \
+        GROUP BY post.Id, author.slug, author.first_name, author.last_name \
         LIMIT #{limit} \
         OFFSET #{offset} \
     "


### PR DESCRIPTION
After sleepless nights of research we decided to migrate our database to postgress to provide best posible experience for our customers. This migration leads to some minor errors related to different syntaxex, so for this pull we just fixing post queries without actually touching selection logic. Optimizations and refactorings are planned for next updates.