### PR TITLE
feat: event but impl

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
       JWT_SECRET: ""
       SERVER_ADDRESS: ""
       PG_URL: ""
+      RABBIT_URL: ""
       TELEGRAM_BOT_TOKEN: ""
 
       TELEGRAM_BOT_LOGIN: ""

--- a/blog-generic/src/events/mod.rs
+++ b/blog-generic/src/events/mod.rs
@@ -1,0 +1,3 @@
+mod subscription_state_changed;
+
+pub use subscription_state_changed::*;

--- a/blog-generic/src/events/subscription_state_changed.rs
+++ b/blog-generic/src/events/subscription_state_changed.rs
@@ -1,0 +1,8 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct SubscriptionStateChanged {
+    pub blog_user_id: u64,
+    pub user_telegram_id: u64,
+    pub new_state: u8,
+}

--- a/blog-generic/src/lib.rs
+++ b/blog-generic/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod entities;
+pub mod events;

--- a/blog-server-api/Cargo.toml
+++ b/blog-server-api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [features]
-ssr = ["blog-ui", "serde_json", "sitemap-rs"]
+ssr = ["blog-ui", "sitemap-rs"]
 yandex = ["reqwest", "blog-ui?/yandex"]
 telegram = ["sha2", "hmac", "hex", "blog-ui?/telegram"]
 
@@ -42,7 +42,7 @@ blog-server-services = { path = "../blog-server-services" }
 tokio = { version = "1.27.0", features = ["full"] }
 hyper = { version = "0.14.26", features = ["full"] }
 serde = { version = "1.0.160", features = ["derive"] }
-serde_json = { version = "1.0.104", optional = true }
+serde_json = { version = "1.0.104" }
 rbs = { version = "4.3" }
 rbatis = { version = "4.3" }
 rbdc-pg = { version = "4.3" }

--- a/blog-server-api/src/endpoints/author_subscribe/handler.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/handler.rs
@@ -44,7 +44,8 @@ async fn http_handler(
             user_telegram_id: telegram_id,
             new_state: subscribe,
         };
-        event_bus_service.publish(event).await;
+
+        tokio::spawn(async move { event_bus_service.publish(event).await });
     } else {
         return Err(NotSupported);
     }

--- a/blog-server-api/src/endpoints/author_subscribe/handler.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/handler.rs
@@ -1,3 +1,5 @@
+use blog_generic::events::SubscriptionStateChanged;
+
 use super::request_content::AuthorSubscribeRequestContent;
 use super::response_content_failure::AuthorSubscribeResponseContentFailure;
 use super::response_content_failure::AuthorSubscribeResponseContentFailure::*;
@@ -20,6 +22,7 @@ async fn http_handler(
         id,
         author_service,
         auth_author_future,
+        event_bus_service,
     }: AuthorSubscribeRequestContent,
     subscribe: u8,
 ) -> Result<AuthorSubscribeRequestContentSuccess, AuthorSubscribeResponseContentFailure> {
@@ -35,11 +38,16 @@ async fn http_handler(
         return Err(Forbidden);
     }
 
-    if author.base.telegram_id.is_none() {
+    if let Some(telegram_id) = author.base.telegram_id {
+        let event = SubscriptionStateChanged {
+            blog_user_id: id,
+            user_telegram_id: telegram_id,
+            new_state: subscribe,
+        };
+        event_bus_service.publish(event).await;
+    } else {
         return Err(NotSupported);
     }
-
-    //TODO PULL Subscribe event INTO QUEUE
 
     author_service
         .set_author_subscription_by_id(&id, &subscribe)

--- a/blog-server-api/src/endpoints/author_subscribe/request_content.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/request_content.rs
@@ -1,6 +1,6 @@
 use crate::extensions::Resolve;
 use crate::utils::auth;
-use blog_server_services::traits::author_service::*;
+use blog_server_services::traits::{author_service::*, event_bus_service::EventBusService};
 use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;
@@ -9,11 +9,12 @@ pub struct AuthorSubscribeRequestContent {
     pub(super) id: String,
     pub(super) author_service: Arc<Box<dyn AuthorService>>,
     pub(super) auth_author_future: DFuture<Result<Author, auth::Error>>,
+    pub(super) event_bus_service: Arc<Box<dyn EventBusService>>,
 }
 
 impl<Extensions> ApiRequestContent<Extensions> for AuthorSubscribeRequestContent
 where
-    Extensions: Resolve<Arc<Box<dyn AuthorService>>>,
+    Extensions: Resolve<Arc<Box<dyn AuthorService>>> + Resolve<Arc<Box<dyn EventBusService>>>,
 {
     type Data = ();
 
@@ -29,6 +30,7 @@ where
                 &origin_content.http_parts,
                 origin_content.extensions.resolve(),
             )),
+            event_bus_service: origin_content.extensions.resolve(),
         }
     }
 }

--- a/blog-server-api/src/endpoints/author_subscribe/request_content.rs
+++ b/blog-server-api/src/endpoints/author_subscribe/request_content.rs
@@ -1,6 +1,7 @@
 use crate::extensions::Resolve;
 use crate::utils::auth;
-use blog_server_services::traits::{author_service::*, event_bus_service::EventBusService};
+use blog_server_services::traits::author_service::*;
+use blog_server_services::traits::event_bus_service::*;
 use screw_api::request::{ApiRequestContent, ApiRequestOriginContent};
 use screw_components::dyn_fn::DFuture;
 use std::sync::Arc;

--- a/blog-server-api/src/extensions.rs
+++ b/blog-server-api/src/extensions.rs
@@ -74,7 +74,7 @@ impl Resolve<Arc<Box<dyn EventBusService>>> for ExtensionsProvider {
 
 pub fn make_extensions(
     rbatis: RBatis,
-    rabbit: Box<dyn EventBusService>,
+    event_bus: Box<dyn EventBusService>,
 ) -> impl ExtensionsProviderType {
     let authors_service = Arc::new(create_rbatis_author_service(rbatis.clone()));
     ExtensionsProvider {
@@ -83,6 +83,6 @@ pub fn make_extensions(
         comment_service: Arc::new(create_rbatis_comment_service(rbatis.clone())),
         entity_comment_service: Arc::new(create_entity_comment_service(authors_service.clone())),
         entity_post_service: Arc::new(create_entity_post_service(authors_service.clone())),
-        event_bus_service: Arc::new(rabbit),
+        event_bus_service: Arc::new(event_bus),
     }
 }

--- a/blog-server-api/src/extensions.rs
+++ b/blog-server-api/src/extensions.rs
@@ -6,6 +6,7 @@ use blog_server_services::traits::author_service::AuthorService;
 use blog_server_services::traits::comment_service::CommentService;
 use blog_server_services::traits::entity_comment_service::EntityCommentService;
 use blog_server_services::traits::entity_post_service::EntityPostService;
+use blog_server_services::traits::event_bus_service::EventBusService;
 use blog_server_services::traits::post_service::PostService;
 use rbatis::rbatis::RBatis;
 use std::sync::Arc;
@@ -20,6 +21,7 @@ pub trait ExtensionsProviderType:
     + Resolve<Arc<Box<dyn CommentService>>>
     + Resolve<Arc<Box<dyn EntityCommentService>>>
     + Resolve<Arc<Box<dyn EntityPostService>>>
+    + Resolve<Arc<Box<dyn EventBusService>>>
 {
 }
 
@@ -29,6 +31,7 @@ struct ExtensionsProvider {
     comment_service: Arc<Box<dyn CommentService>>,
     entity_comment_service: Arc<Box<dyn EntityCommentService>>,
     entity_post_service: Arc<Box<dyn EntityPostService>>,
+    event_bus_service: Arc<Box<dyn EventBusService>>,
 }
 
 impl ExtensionsProviderType for ExtensionsProvider {}
@@ -63,7 +66,16 @@ impl Resolve<Arc<Box<dyn EntityPostService>>> for ExtensionsProvider {
     }
 }
 
-pub fn make_extensions(rbatis: RBatis) -> impl ExtensionsProviderType {
+impl Resolve<Arc<Box<dyn EventBusService>>> for ExtensionsProvider {
+    fn resolve(&self) -> Arc<Box<dyn EventBusService>> {
+        self.event_bus_service.clone()
+    }
+}
+
+pub fn make_extensions(
+    rbatis: RBatis,
+    rabbit: Box<dyn EventBusService>,
+) -> impl ExtensionsProviderType {
     let authors_service = Arc::new(create_rbatis_author_service(rbatis.clone()));
     ExtensionsProvider {
         author_service: authors_service.clone(),
@@ -71,5 +83,6 @@ pub fn make_extensions(rbatis: RBatis) -> impl ExtensionsProviderType {
         comment_service: Arc::new(create_rbatis_comment_service(rbatis.clone())),
         entity_comment_service: Arc::new(create_entity_comment_service(authors_service.clone())),
         entity_post_service: Arc::new(create_entity_post_service(authors_service.clone())),
+        event_bus_service: Arc::new(rabbit),
     }
 }

--- a/blog-server-api/src/main.rs
+++ b/blog-server-api/src/main.rs
@@ -11,15 +11,18 @@ const SITE_URL: &'static str = std::env!("SITE_URL"); // http://127.0.0.1:3000
 const JWT_SECRET: &'static str = std::env!("JWT_SECRET"); // 123
 const SERVER_ADDRESS: &'static str = std::env!("SERVER_ADDRESS"); // 127.0.0.1:3000
 const PG_URL: &'static str = std::env!("PG_URL"); // postgres://postgres:postgres@localhost:5432/blog
+const RABBIT_URL: &'static str = std::env!("RABBIT_URL"); // amqp://guest:guest@localhost:5672/
 const TELEGRAM_BOT_TOKEN: &'static str = std::env!("TELEGRAM_BOT_TOKEN"); // XXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXX
 
 #[tokio::main]
 async fn main() -> screw_components::dyn_result::DResult<()> {
     let rbatis = init_db().await;
 
+    let rabbit = init_rabbit().await;
+
     let server_service = screw_core::server::ServerService::with_responder_factory(
         screw_core::responder_factory::ResponderFactory::with_router(router::make_router())
-            .and_extensions(extensions::make_extensions(rbatis)),
+            .and_extensions(extensions::make_extensions(rbatis, rabbit)),
     );
 
     let addr = SERVER_ADDRESS.parse()?;
@@ -36,4 +39,13 @@ pub async fn init_db() -> rbatis::RBatis {
     let sql = std::fs::read_to_string("./table_pg.sql").unwrap();
     rb.exec(&sql, vec![]).await.expect("DB migration failed");
     return rb;
+}
+
+pub async fn init_rabbit(
+) -> Box<dyn blog_server_services::traits::event_bus_service::EventBusService> {
+    if RABBIT_URL.is_empty() {
+        blog_server_services::impls::create_rabbit_event_bus_service(None).await
+    } else {
+        blog_server_services::impls::create_rabbit_event_bus_service(Some(RABBIT_URL)).await
+    }
 }

--- a/blog-server-services/Cargo.toml
+++ b/blog-server-services/Cargo.toml
@@ -12,6 +12,7 @@ package = "screw-components"
 blog-generic = { path = "../blog-generic" }
 rbs = { version = "4.3" }
 rbatis = { version = "4.3" }
+amqprs = { version = "1.5.1", features = ["urispec"] }
 async-trait = { version = "0.1.68" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_repr = { version = "0.1.12" }

--- a/blog-server-services/src/impls/mod.rs
+++ b/blog-server-services/src/impls/mod.rs
@@ -1,5 +1,6 @@
 mod entity_comment_service;
 mod entity_post_service;
+mod rabbitmq_event_bus_service;
 mod rbatis_author_service;
 mod rbatis_comment_service;
 mod rbatis_post_service;
@@ -9,3 +10,5 @@ pub use entity_post_service::create_entity_post_service;
 pub use rbatis_author_service::create_rbatis_author_service;
 pub use rbatis_comment_service::create_rbatis_comment_service;
 pub use rbatis_post_service::create_rbatis_post_service;
+
+pub use rabbitmq_event_bus_service::create_rabbit_event_bus_service;

--- a/blog-server-services/src/impls/rabbitmq_event_bus_service.rs
+++ b/blog-server-services/src/impls/rabbitmq_event_bus_service.rs
@@ -1,0 +1,160 @@
+use amqprs::{
+    callbacks::{DefaultChannelCallback, DefaultConnectionCallback},
+    channel::{BasicPublishArguments, Channel, QueueBindArguments},
+    connection::{Connection, OpenConnectionArguments},
+    error::Error,
+    BasicProperties,
+};
+use blog_generic::events::SubscriptionStateChanged;
+use serde::Serialize;
+
+use crate::traits::event_bus_service::{EventBusService, Publish};
+
+enum EventBusError {
+    SerializationError,
+    PublishingError,
+}
+
+pub async fn create_rabbit_event_bus_service(
+    connection_string: Option<&str>,
+) -> Box<dyn EventBusService> {
+    if let Some(connection) = connection_string {
+        let connection_configuration: Result<OpenConnectionArguments, _> = connection.try_into();
+        let connection_configuration = match connection_configuration {
+            Ok(mut config) => {
+                config.connection_name("blog_producer");
+                config
+            }
+            Err(_) => {
+                println!("Error while connecting to rabbitMQ. Mock service will be created");
+                return Box::new(NotificationServiceMock);
+            }
+        };
+
+        let mut service = RabbitEventBusService::new(connection_configuration);
+        if service.connect().await.is_ok() {
+            return Box::new(service);
+        } else {
+            println!("Error while connecting to rabbitMQ. Mock service will be created");
+        }
+    }
+
+    Box::new(NotificationServiceMock)
+}
+
+const ROUTING_KEY: &'static str = "blog.events";
+const EXCHANGE_NAME: &'static str = "blog.events";
+const QUEUE_NAME: &'static str = "blog.events";
+
+struct RabbitEventBusService {
+    connection_configuration: OpenConnectionArguments,
+    connection: Option<Connection>,
+    channel: Option<Channel>,
+}
+
+impl RabbitEventBusService {
+    fn new(connection_configuration: OpenConnectionArguments) -> RabbitEventBusService {
+        println!("RabbitEventBusService created");
+        RabbitEventBusService {
+            connection_configuration,
+            connection: None,
+            channel: None,
+        }
+    }
+}
+
+impl EventBusService for RabbitEventBusService {}
+
+#[async_trait]
+trait Connect {
+    async fn connect(&mut self) -> Result<(), Error>;
+}
+
+//TODO setup correct callback (defaults are "for demo and debugging purposes only")
+#[async_trait]
+impl Connect for RabbitEventBusService {
+    async fn connect(&mut self) -> Result<(), Error> {
+        if self.connection.is_some() {
+            return Ok(());
+        }
+
+        let new_connection = Connection::open(&self.connection_configuration).await?;
+        new_connection
+            .register_callback(DefaultConnectionCallback)
+            .await?;
+
+        let channel = new_connection.open_channel(None).await.unwrap();
+        channel.register_callback(DefaultChannelCallback).await?;
+
+        channel
+            .queue_bind(QueueBindArguments::new(
+                &QUEUE_NAME,
+                EXCHANGE_NAME,
+                ROUTING_KEY,
+            ))
+            .await?;
+
+        self.connection = Some(new_connection);
+        self.channel = Some(channel);
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Publish<SubscriptionStateChanged> for RabbitEventBusService {
+    async fn publish(&self, event: SubscriptionStateChanged) -> () {
+        println!(
+            "event published: {}, {}",
+            event.blog_user_id, event.user_telegram_id
+        );
+
+        publish(to_bytes_payload(event), self.channel.clone()).await;
+    }
+}
+
+async fn publish(payload: Result<Vec<u8>, EventBusError>, channel: Option<Channel>) -> () {
+    if let (Ok(payload), Some(channel)) = (payload, channel) {
+        let res = internal_publish(payload, &channel).await;
+        if res.is_err() {
+            println!("Error while publishing message");
+        }
+    } else {
+        println!("Error while parsing event");
+    }
+}
+
+fn to_bytes_payload<T: Serialize>(event: T) -> Result<Vec<u8>, EventBusError> {
+    match serde_json::to_string(&event) {
+        Ok(json_string) => Ok(json_string.into_bytes()),
+        Err(_) => Err(EventBusError::SerializationError),
+    }
+}
+
+//TODO add publisher confirms
+async fn internal_publish(payload: Vec<u8>, channel: &Channel) -> Result<(), EventBusError> {
+    let args = BasicPublishArguments::new(EXCHANGE_NAME, ROUTING_KEY);
+
+    match channel
+        .basic_publish(BasicProperties::default(), payload, args)
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(_) => Err(EventBusError::PublishingError),
+    }
+}
+
+//TODO Mock Service remove after notification service implemented
+struct NotificationServiceMock;
+
+impl EventBusService for NotificationServiceMock {}
+
+#[async_trait]
+impl Publish<SubscriptionStateChanged> for NotificationServiceMock {
+    async fn publish(&self, event: SubscriptionStateChanged) -> () {
+        println!(
+            "event NOT published. Mock eventBus is used: {}, {}",
+            event.blog_user_id, event.user_telegram_id
+        );
+    }
+}

--- a/blog-server-services/src/traits/event_bus_service.rs
+++ b/blog-server-services/src/traits/event_bus_service.rs
@@ -1,0 +1,11 @@
+use blog_generic::events::SubscriptionStateChanged;
+use serde::Serialize;
+#[async_trait]
+pub trait Publish<T>: Send + Sync
+where
+    T: Serialize,
+{
+    async fn publish(&self, event: T) -> ();
+}
+
+pub trait EventBusService: Publish<SubscriptionStateChanged> {}

--- a/blog-server-services/src/traits/mod.rs
+++ b/blog-server-services/src/traits/mod.rs
@@ -2,4 +2,5 @@ pub mod author_service;
 pub mod comment_service;
 pub mod entity_comment_service;
 pub mod entity_post_service;
+pub mod event_bus_service;
 pub mod post_service;


### PR DESCRIPTION
Basic implementation for rabbitMq that supports sending simple messages (bytes payload) into predefined queue.

We using default callbacks that should be replaced with correct ones in next updates (maybe(not sure(meeeh)))

Also until entire "notification" feature is done we could use Mock service that will not require any RabbitMQ connection.  New env variable should be empty.